### PR TITLE
Lower numpy minimum version from 2.3.1 to 1.25.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ qbraid>=0.11.0
 pyqasm>=0.5.0,<1.1.0
 sympy>=1.14.0
 scipy>=1.16.0
-numpy>=2.3.1
+numpy>=1.25.2
 networkx>=3.1.0


### PR DESCRIPTION
## Summary
- Lowers the numpy lower bound from `>=2.3.1` to `>=1.25.2`
- The codebase only uses basic numpy APIs (array creation, linalg, FFT, trig) available since ~1.13
- The practical floor of 1.25.2 is dictated by `scipy>=1.16.0`'s own numpy requirement and Python >=3.11 compatibility

## Test plan
- [ ] Verify tests pass with numpy 1.25.2 installed
- [ ] Verify tests pass with latest numpy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum NumPy version requirement from 2.3.1 to 1.25.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->